### PR TITLE
fix no results showing on initial load

### DIFF
--- a/src/app/ResultsList.tsx
+++ b/src/app/ResultsList.tsx
@@ -21,12 +21,12 @@ export const ResultsList = ({results, showScore, scoreCutoff}:ResultsListProps) 
   const [showLessRelevant, setShowLessRelevant] = useState(false);
   const [haveLessRelevant, setHaveLessRelevant] = useState(false);
 
-  const resultsToRender = scoreCutoff && !showLessRelevant ? results.filter((r)=>r.score>scoreCutoff) : results;
+  const resultsToRender = scoreCutoff && !showLessRelevant ? results.filter((r)=>(r.score ?? 100)>scoreCutoff) : results;
 
   useEffect(() => {
     if(results.length>0) {
       const lastResult = results[results.length - 1];
-      setHaveLessRelevant(lastResult.score <= (scoreCutoff ?? 0));
+      setHaveLessRelevant((lastResult.score ?? 100) <= (scoreCutoff ?? 0));
     } else {
       setHaveLessRelevant(false);
     }

--- a/src/app/SuggestionComponent.tsx
+++ b/src/app/SuggestionComponent.tsx
@@ -9,7 +9,7 @@ interface SuggestionComponentProps {
 }
 
 export const SuggestionComponent = (props:SuggestionComponentProps) => {
-  return props.matches.map(suggestion=><li css={sideScollingListItem}>
+  return props.matches.map((suggestion, ctr)=><li css={sideScollingListItem} key={ctr}>
           <Paper elevation={1}>
             {
               props.renderContent(suggestion)

--- a/src/service/schema.ts
+++ b/src/service/schema.ts
@@ -1,7 +1,7 @@
 import {  z } from 'zod';
 
 export const TitleSearchResult = z.object({
-  score: z.number(),
+  score: z.number().optional(),
   title: z.string(),
   href: z.string(),
   composerId: z.string()


### PR DESCRIPTION
## What does this change?

https://github.com/guardian/recipe-search-backend/pull/48 accidentally broke the UI, because the default behaviour on no search query changed. Before, an empty string was vectorised; now, the current most recent results are shown. this means that the scoring field disappeared, which broke the UI.

## How to test

Load the UI. It should not display empty.

## How can we measure success?

UI works again

## Have we considered potential risks?

n/a
