### PR TITLE
update incoming json schema

### DIFF
--- a/src/service/schema.ts
+++ b/src/service/schema.ts
@@ -4,7 +4,10 @@ export const TitleSearchResult = z.object({
   score: z.number().optional(),
   title: z.string(),
   href: z.string(),
-  composerId: z.string()
+  featuredImage: z.string().optional().nullable(),
+  contributors: z.array(z.string()).optional().nullable(),
+  byline: z.array(z.string()).optional().nullable(),
+  dietIds: z.array(z.string()).optional().nullable(),
 });
 
 export type TitleSearchResult = z.infer<typeof TitleSearchResult>;


### PR DESCRIPTION
## What does this change?

https://github.com/guardian/recipe-search-backend/pull/55 removes the `composerId` field from the default "summary" api response and inserts some other fields.

This PR updates the zod schema to reflect this

## How to test

Load it up. You should see results (without it, nothing gets displayed due to zod parse error)

## How can we measure success?

Working UI again