### PR TITLE
update to not require `hits` any more

### DIFF
--- a/src/app/SearchPane.tsx
+++ b/src/app/SearchPane.tsx
@@ -177,7 +177,7 @@ export const SearchPane = () => {
           {
             weHaveNoRelevantResults ?
               <Typography>We couldn't find any recipes that seemed very relevant, but here are some that might interest you</Typography> :
-              <Typography>We found {searchHits} recipes that might interest you...</Typography>
+              <Typography>These recipes might interest you...</Typography>
           }
         </span>
         <ResultsList results={results} showScore scoreCutoff={effectiveCutoff()}/>

--- a/src/service/schema.ts
+++ b/src/service/schema.ts
@@ -47,7 +47,6 @@ export const StatsEntry = z.object({
 export type StatsEntry = z.infer<typeof StatsEntry>;
 
 export const RecipeSearchResponse = z.object({
-  hits: z.number(),
   maxScore: z.number().nullable().optional(),
   results: z.array(TitleSearchResult),
   stats: z.record(z.string(), StatsEntry)


### PR DESCRIPTION
## What does this change?

We dropped the `hits` field from the recipe search API as it has become progressively more meaningless.  This updates the UI to reflect that

## How to test

It should work, but you no longer see `we found 75 recipes which might interest you`

## How can we measure success?
UI works again

## Have we considered potential risks?

n/a