### PR TITLE
Add selector to choose searching mode

### DIFF
--- a/src/service/SearchService.ts
+++ b/src/service/SearchService.ts
@@ -26,9 +26,11 @@ export interface RecipeSearchFilters {
   filterType?: "Post"|"During";
 }
 
+export type SearchTypes = "Embedded"|"WeightedHybridSum"|"Match"|"Lucene";
+
 interface RecipeSearchParams {
   queryText: string;
-  searchType?: "Embedded"|"Match"|"Lucene";
+  searchType?: SearchTypes;
   fields?: (string|FieldWithWeighting)[];
   filters?: RecipeSearchFilters;
   limit?: number

--- a/src/service/schema.ts
+++ b/src/service/schema.ts
@@ -49,7 +49,7 @@ export type StatsEntry = z.infer<typeof StatsEntry>;
 export const RecipeSearchResponse = z.object({
   maxScore: z.number().nullable().optional(),
   results: z.array(TitleSearchResult),
-  stats: z.record(z.string(), StatsEntry)
+  stats: z.record(z.string(), StatsEntry).optional()
 });
 
 export type RecipeSearchResponse = z.infer<typeof RecipeSearchResponse>;


### PR DESCRIPTION
## What does this change?

Adds a drop-down selector to the right of the upper search box, which allows you to switch the search mode.  This is especially useful to test out "beta" search algorithms/implementations

## How to test

Do some searches across the different versions and see them work.

NOTE: on CODE some searches can cause 503s if you send requests too quickly. Be aware of this.

## How can we measure success?

Able to test hybrid search better

## Have we considered potential risks?

n/a

## Images

<img width="335" alt="Screenshot 2025-02-20 at 16 37 51" src="https://github.com/user-attachments/assets/417982a3-964d-4c94-b02a-f6f169de6774" />
